### PR TITLE
Add Fun with Quantum family footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="{{ site.lang | default: "en-US" }}">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+{% seo %}
+    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+    <script src="https://code.jquery.com/jquery-3.3.0.min.js" integrity="sha256-RTQy8VOmNlT6b2PIRur37p6JEBZUE7o8wPgMvu18MC4=" crossorigin="anonymous"></script>
+    <script src="{{ '/assets/js/main.js' | relative_url }}"></script>
+    <!--[if lt IE 9]>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" integrity="sha256-3Jy/GbSLrg0o9y5Z5n1uw0qxZECH7C6OQpVBgNFYa0g=" crossorigin="anonymous"></script>
+    <![endif]-->
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+
+    {% include head-custom.html %}
+  </head>
+  <body>
+
+      <header>
+        <h1>{{ page.title | default: site.title | default: site.github.repository_name }}</h1>
+        <p>{{ page.description | default: site.description | default: site.github.project_tagline }}</p>
+      </header>
+
+      <div id="banner">
+        <span id="logo"></span>
+
+        <a href="{{ site.github.repository_url }}" class="button fork"><strong>View On GitHub</strong></a>
+        {% if site.show_downloads %}
+          <div class="downloads">
+            <span>Downloads:</span>
+            <ul>
+              <li><a href="{{ site.github.zip_url }}" class="button">ZIP</a></li>
+              <li><a href="{{ site.github.tar_url }}" class="button">TAR</a></li>
+            </ul>
+          </div>
+        {% endif %}
+      </div><!-- end banner -->
+
+    <div class="wrapper">
+      <nav>
+        <ul></ul>
+      </nav>
+      <section>
+        {{ content }}
+
+        <!-- Fun with Quantum family footer -->
+        <hr>
+        <p><small style="font-family: monospace; letter-spacing: 0.05em;">GOD DOES PLAY DICE. COME PLAY, BUILD, LEARN.</small></p>
+        <p><small>Part of the Fun with Quantum family:
+          <a href="https://fun-with-quantum.org" target="_blank" rel="noopener">Fun with Quantum</a> &middot;
+          <a href="https://rasqberry.org" target="_blank" rel="noopener">RasQberry Two</a> &middot;
+          <a href="https://quantego.org" target="_blank" rel="noopener">Quantego</a> &middot;
+          <a href="https://qutie.org" target="_blank" rel="noopener">Qutie</a> &middot;
+          <a href="https://qoffee-maker.org" target="_blank" rel="noopener">Qoffee-Maker</a></small></p>
+        <p><small>Open source, built by Jan-R. Lahmann and the RasQberry community.</small></p>
+
+      </section>
+      <footer>
+        {% if site.github.is_project_page %}
+          <p>Project maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></p>
+        {% endif %}
+        <p><small>Hosted on GitHub Pages &mdash; Theme by <a href="https://twitter.com/mattgraham">mattgraham</a></small></p>
+      </footer>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Adds the shared "Fun with Quantum family" footer for cross-traffic across the family sites, matching the footers already live on fun-with-quantum.org and qutie.org.

## Changes
- `_layouts/default.html` (new file): overrides the `jekyll-theme-leap-day` theme's default layout — an exact copy of the upstream layout, plus a small family-footer block appended after `{{ content }}` in the main section:
  - the family tagline ("GOD DOES PLAY DICE. COME PLAY, BUILD, LEARN.") in small monospace
  - "Part of the Fun with Quantum family:" with links to fun-with-quantum.org, rasqberry.org, quantego.org, qutie.org, and qoffee-maker.org (this site itself is excluded)
  - "Open source, built by Jan-R. Lahmann and the RasQberry community."

The footer lands in the content column on every page (the theme's own fixed sidebar footer is too small for the link list). Layout override is the standard GitHub Pages theme customization path, so the diff outside the new block is zero relative to upstream.

## Verification
Static inspection only: this is a legacy GitHub Pages (Jekyll) build, so there is no local build step here. The added block is plain HTML using the theme's existing `<small>`/`<hr>` styling; the surrounding layout is byte-for-byte the upstream `pages-themes/leap-day` layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)