### PR TITLE
Add Umami analytics (shared family property)

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,6 +12,7 @@
       <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" integrity="sha256-3Jy/GbSLrg0o9y5Z5n1uw0qxZECH7C6OQpVBgNFYa0g=" crossorigin="anonymous"></script>
     <![endif]-->
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+    <script defer src="https://cloud.umami.is/script.js" data-website-id="97f347ac-e7ba-4be3-b26f-ab4b328bdbf2" data-domains="rasqberry.one"></script>
 
     {% include head-custom.html %}
   </head>


### PR DESCRIPTION
Adds cookieless Umami Cloud analytics to the site `<head>`.

- Shared website ID across the Fun with Quantum family; per-site hostname filtering happens in the Umami dashboard.
- No cookies, so no consent banner is needed.
- `data-domains="rasqberry.one"` keeps localhost/preview traffic out of the stats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)